### PR TITLE
Bugfix/content block body content parsing

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,7 +19,7 @@ env :BUNDLE_PATH, '/usr/local/bundle'
 env :GEM_HOME, '/usr/local/bundle'
 env :BUNDLE_APP_CONFIG, '/usr/local/bundle'
 
-every 1.hour do
+every 5.minutes do
   runner "RssFeeds.import"
 end
 

--- a/doc/parsed_json_2907.json
+++ b/doc/parsed_json_2907.json
@@ -1,0 +1,344 @@
+{
+  "news": [
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=372076",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Thu, 10 Jan 2019 14:00:45 +0100",
+      "contentBlocks": [
+        {
+          "body": "In der Zeit vom 20.06.2019 bis zum 03.08.2019 sind in Brandenburg Schulferien. Der BürgerBus fährt daher in dieser Zeit nach dem Ferienfahrplan.\n\nWir bitten, dies zu beachten.<br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=372076\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "01.06.2019: Achtung Ferienfahrplan bitte beachten."
+        }
+      ],
+      "publication_date": "Thu, 10 Jan 2019 14:00:45 +0100"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=506696",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Wed, 29 May 2019 13:59:07 +0200",
+      "contentBlocks": [
+        {
+          "body": "Unter diesem Link finden Sie die Bekanntmachung der  Wahlergebnisse.\n\n \n\nBekanntmachung der Wahlergebnisse<br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=506696\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "29.05.2019: Bekanntmachung der Wahlergebnisse"
+        }
+      ],
+      "publication_date": "Wed, 29 May 2019 13:59:07 +0200"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=505846",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Mon, 27 May 2019 03:16:02 +0200",
+      "contentBlocks": [
+        {
+          "body": "Unter diesem Link finden Sie die vorläufigem Wahlergebnisse.\n\n \n\nWahlergebnisse der Europa-, Kreis- und Kommunalwahl<br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=505846\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "27.05.2019: Wahlergebnisse der Europa-, Kreis und Kommunalwahl"
+        }
+      ],
+      "publication_date": "Mon, 27 May 2019 03:16:02 +0200"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=505455",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Mon, 17 Jun 2019 14:44:59 +0200",
+      "contentBlocks": [
+        {
+          "body": "<img src=\"https://vorschau.verwaltungsportal.de/news/5/0/5/4/5/5/1227039976.jpg\" alt=\"Stellenausschreibung: Schulsozialarbeiter*innen (w/m/d) gesucht\" /><br /><br /> Das Diakonische Werk im Landkreis Potsdam-Mittelmark e.V. mit Sitz in Bad Belzig ist ein anerkannter Jugendhilfeträger und sucht zum nächstmöglichen Zeitpunkt \n\n \n\nSozialarbeiter*innen an ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=505455\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "24.05.2019: Stellenausschreibung: Schulsozialarbeiter*innen (w/m/d) gesucht"
+        }
+      ],
+      "publication_date": "Mon, 17 Jun 2019 14:44:59 +0200"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=503395",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Tue, 21 May 2019 12:56:01 +0200",
+      "contentBlocks": [
+        {
+          "body": "Streetsoccer-Turnier\n\nAuch in diesem Jahr wird an der Geschwister-Scholl-Grundschule in Bad Belzig des beste Streetsoccer-Team gesucht.\n\nAm Samstag, den 25.05.2019, werden in der Zeit von ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=503395\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "14.05.2019: Streetsoccer-Turnier am Samstag, den 25.05.2019 in der Zeit von 10-16:30 Uhr"
+        }
+      ],
+      "publication_date": "Tue, 21 May 2019 12:56:01 +0200"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=499685",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Thu, 18 Apr 2019 13:59:51 +0200",
+      "contentBlocks": [
+        {
+          "body": "Mit der anhaltenden Trockenheit ist die Waldbrandgefahrenstufe derzeit auf Stufe 4 (hohe Gefahr). Es ist damit zu rechnen, dass ab dem 19.04.2019 die Waldbrandgefahrenstufe 5 (sehr hohe Gefahr) gilt. ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=499685\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "18.04.2019: Untersagung von Brauchtumsfeuer anlässlich des Osterfestes"
+        }
+      ],
+      "publication_date": "Thu, 18 Apr 2019 13:59:51 +0200"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=502003",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Mon, 06 May 2019 12:59:08 +0200",
+      "contentBlocks": [
+        {
+          "body": "<img src=\"https://vorschau.verwaltungsportal.de/news/5/0/2/0/0/3/2044436850.jpg\" alt=\"WETTBEWERB NEUBAU STÜTZPUNKTFEUERWEHR BAD BELZIG\" /><br /><br /> WETTBEWERB NEUBAU STÜTZPUNKTFEUERWEHR BAD BELZIG\n\n \n\nANLASS\n\nAuf Grundlage einer Voruntersuchung hatte sich die Stadt Bad Belzig für den Neubau einer Stützpunktfeuerwehr entschieden, da der ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=502003\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "02.04.2019: WETTBEWERB NEUBAU STÜTZPUNKTFEUERWEHR BAD BELZIG"
+        }
+      ],
+      "publication_date": "Mon, 06 May 2019 12:59:08 +0200"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=496837",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Tue, 02 Apr 2019 21:30:42 +0200",
+      "contentBlocks": [
+        {
+          "body": "<img src=\"https://vorschau.verwaltungsportal.de/news/4/9/6/8/3/7/4103594917.png\" alt=\"Landcafé mit Osterbasteleien\" /><br /><br /> Zu hausgebackenem Kuchen und Kaffee luden wir in die gemütlich geheizte Alte Schmiede ein.\n\nPassend zur nahen Osterzeit hatten wir diesmal auch Anleitungen zu Osterbasteleien im Angebote. Es ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=496837\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "31.03.2019: Landcafé mit Osterbasteleien"
+        }
+      ],
+      "publication_date": "Tue, 02 Apr 2019 21:30:42 +0200"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=495859",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Thu, 28 Mar 2019 12:55:49 +0100",
+      "contentBlocks": [
+        {
+          "body": "aktueller veranstaltungsplan der kreislichen Veranstaltungen<br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=495859\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "28.03.2019: aktueller Veranstaltungsplan"
+        }
+      ],
+      "publication_date": "Thu, 28 Mar 2019 12:55:49 +0100"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=493027",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Tue, 12 Mar 2019 14:19:32 +0100",
+      "contentBlocks": [
+        {
+          "body": "Die Stadtverwaltung Bad Belzig sucht für die Badesaison 2019 Rettungsschwimmer für die Badaufsicht und den Kassenbetrieb.\n\nDie Beschäftigung erfolgt witterungsabhängig von Mai bis Mitte ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=493027\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "12.03.2019: Rettungsschwimmer gesucht"
+        }
+      ],
+      "publication_date": "Tue, 12 Mar 2019 14:19:32 +0100"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=479822",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Wed, 12 Dec 2018 09:28:59 +0100",
+      "contentBlocks": [
+        {
+          "body": "<img src=\"https://vorschau.verwaltungsportal.de/news/4/7/9/8/2/2/4288582224.jpg\" alt=\"Es knallt an der „Carl-von-Ossietzky“ Oberschule mit angegliederter Primarstufe\" /><br /><br /> Und zwar richtig laut. Erst explodiert ein Schuh und fliegt dabei 4 m in die Luft. Dann eine Pfote eines Schweines. Der Schreck über den lauten Knall sitzt bei den je rund 100 Schülerinnen und ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=479822\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "12.12.2018: Es knallt an der „Carl-von-Ossietzky“ Oberschule mit angegliederter Primarstufe"
+        }
+      ],
+      "publication_date": "Wed, 12 Dec 2018 09:28:59 +0100"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=479076",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Thu, 28 Mar 2019 13:01:26 +0100",
+      "contentBlocks": [
+        {
+          "body": "Vorführ- und Mitmachküche\n\nTermine:\n\n07.05.2019 Färberpflanzen Einladung siehe Startseite\n\n03.04.2019 Gärtnern im Klimawandel Einladung siehe Stratseite\n\n21.03.2019 Süße Teilchen ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=479076\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "01.12.2018: Küchenveranstaltungen"
+        }
+      ],
+      "publication_date": "Thu, 28 Mar 2019 13:01:26 +0100"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=477559",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Thu, 29 Nov 2018 11:56:47 +0100",
+      "contentBlocks": [
+        {
+          "body": "<img src=\"https://vorschau.verwaltungsportal.de/news/4/7/7/5/5/9/2554828672.jpg\" alt=\"Zusammenarbeit besiegelt\" /><br /><br /> Mit Beginn des Schuljahres 2018/2019 wurde das Treuenbrietzener Gymnasium &quot;Am Burgwall&quot; in eine Gesamtschule umgewandelt. Am selben Standort haben fortan die Schüler*innen ab der Klassenstufe 7 die ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=477559\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "29.11.2018: Zusammenarbeit besiegelt"
+        }
+      ],
+      "publication_date": "Thu, 29 Nov 2018 11:56:47 +0100"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=476452",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Fri, 23 Nov 2018 15:08:13 +0100",
+      "contentBlocks": [
+        {
+          "body": "<img src=\"https://vorschau.verwaltungsportal.de/news/4/7/6/4/5/2/3880308195.jpg\" alt=\"Landestreffen der Schulen ohne Rassismus\" /><br /><br /> Begleitet von Jördis Freiwald und Sven Gatter (Schulische Sozialarbeit, Diakonisches Werk im Landkreis Potsdam-Mittelmark e.V.) haben Schüler*innen der Oberschule Werder und der Gesamtschule ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=476452\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "23.11.2018: Landestreffen der Schulen ohne Rassismus"
+        }
+      ],
+      "publication_date": "Fri, 23 Nov 2018 15:08:13 +0100"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=471706",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Thu, 25 Oct 2018 09:22:49 +0200",
+      "contentBlocks": [
+        {
+          "body": "<img src=\"https://vorschau.verwaltungsportal.de/news/4/7/1/7/0/6/627212655.jpg\" alt=\"Projekt der Niemegker Schulsozialarbeiterin ausgezeichnet\" /><br /><br /> Die Freude war groß als ein Brief der Mittelbrandenburgischen Sparkasse in die Geschäftsstelle des Diakonischen Werkes im Landkreis Potsdam-Mittelmark flatterte.\n\n \n\nDas Projekt &quot;Full of ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=471706\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "25.10.2018: Projekt der Niemegker Schulsozialarbeiterin ausgezeichnet"
+        }
+      ],
+      "publication_date": "Thu, 25 Oct 2018 09:22:49 +0200"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=456011",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Fri, 06 Jul 2018 09:11:21 +0200",
+      "contentBlocks": [
+        {
+          "body": "Veranstaltunskalender des Kreisverbandes 2018<br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=456011\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "06.07.2018: Veranstaltungsplan 2018"
+        }
+      ],
+      "publication_date": "Fri, 06 Jul 2018 09:11:21 +0200"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=436217",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Fri, 02 Mar 2018 07:44:40 +0100",
+      "contentBlocks": [
+        {
+          "body": "<img src=\"https://vorschau.verwaltungsportal.de/news/4/3/6/2/1/7/2192608227.png\" alt=\"Videoabend\" /><br /><br /> Wenn es draußen kalt ist, muss man sich warme Gedanken machen… \n\n \n\nDachten wir uns und luden deshalb ein, am warmen Ofen zusammen zu kommen und noch einmal das Video unserer gemeinsamen ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=436217\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "23.02.2018: Videoabend"
+        }
+      ],
+      "publication_date": "Fri, 02 Mar 2018 07:44:40 +0100"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=433151",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Fri, 02 Mar 2018 07:40:01 +0100",
+      "contentBlocks": [
+        {
+          "body": "<img src=\"https://vorschau.verwaltungsportal.de/news/4/3/3/1/5/1/578996970.png\" alt=\"Winterwanderung\" /><br /><br /> Zu einer Winterwanderung bei herrlichem Sonnenschein von Lütte über den Galgenberg ins Paradies luden wir am 28. Januar ein.\n\nDort stärkten wir uns und kehrten dann wieder nach Lütte ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=433151\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "28.01.2018: Winterwanderung"
+        }
+      ],
+      "publication_date": "Fri, 02 Mar 2018 07:40:01 +0100"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=428572",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Tue, 16 Jan 2018 17:19:10 +0100",
+      "contentBlocks": [
+        {
+          "body": "Liebe Fahrgäste,\n\nBitte wählen Sie 0331 7491 400.\n\nDiese Nummer ist auch zukünftig immer gültig.\n\nDie bisherige Telefonnummer leitet nicht mehr weiter an die Vermittlung.\n\nGute ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=428572\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "14.01.2018: Rufbusnummer 0331 7491 400"
+        }
+      ],
+      "publication_date": "Tue, 16 Jan 2018 17:19:10 +0100"
+    },
+    {
+      "author": "",
+      "news_type": "news",
+      "source_url": {
+        "url": "http://www.bad-belzig.de/news/index.php?news=421781",
+        "description": "source url of original article"
+      },
+      "full_version": false,
+      "published_at": "Mon, 27 Nov 2017 11:54:08 +0100",
+      "contentBlocks": [
+        {
+          "body": "<img src=\"https://vorschau.verwaltungsportal.de/news/4/2/1/7/8/1/3625743405.png\" alt=\"Adventsbasteln\" /><br /><br /> Mittlerweile schon zur Tradition geworden, luden wir zum gemeinsamen Adventsbasteln in das Alte Haus ein.\n\n \n\nVor dem geheizten Ofen wurden in fröhlicher Runde Adventskränze gebunden. Die ... <br /><br />[<a href=\"http://www.bad-belzig.de/news/index.php?news=421781\" title=\"Zur Meldung\">mehr</a>]",
+          "title": "25.11.2017: Adventsbasteln"
+        }
+      ],
+      "publication_date": "Mon, 27 Nov 2017 11:54:08 +0100"
+    }
+  ]
+}


### PR DESCRIPTION
Implement change in rss feed

* flaeming365 now provides a namepsace content with encoded data
* parsing was failing because namespaces were removed globally in parser method
*  removed #remove_namespaces! method and wrote parse_content method which either  uses content:encoded or description(fallback) to provide {content_block: body} for a news_item
* temporarily change rss import to every 5 minutes
* add example json to doc folder.